### PR TITLE
Fixed the incomplete ValidGenomicLocation interface

### DIFF
--- a/web/src/main/java/org/cbioportal/genome_nexus/web/validation/ValidGenomicLocation.java
+++ b/web/src/main/java/org/cbioportal/genome_nexus/web/validation/ValidGenomicLocation.java
@@ -1,6 +1,7 @@
 package org.cbioportal.genome_nexus.web.validation;
 
 import javax.validation.Constraint;
+import javax.validation.Payload;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -13,4 +14,6 @@ import java.lang.annotation.Target;
 @Constraint(validatedBy = { GenomicLocationValidator.class })
 public @interface ValidGenomicLocation {
     String message() default "genomicLocation is incorrect";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
 }


### PR DESCRIPTION
Seems like the `ValidGenomicLocation` interface was missing some default methods, which also somehow was affecting other endpoints. This also fixes integration tests.